### PR TITLE
[93] Add one liner to enable token

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ On both the RM and RAS environments there are the following options for the star
 
 
 ## Testing the installation
-  
-### IAC Activation
-The installation uploads the required data to run through a user journey. It requires activation of the iac ﻿4kyznty4fw3s, in the rm-postgres DB in iac.iac. This is done by toggling the active boolean.
 
-The rest of the test data is valid for a run through of an entire user journey. 
+### IAC Activation
+  The installation uploads the required data to run through a user journey. The users are all disabled, to enable a token to create a user run the following
+```bash
+docker exec -it postgres psql -U postgres -d postgres -c "update iac.iac set active = 't' where code = '4kyznty4fw3s'"
+```
 
 ###  Activating the email
 The activation url for email can be pulled from the party-service logs, append the url to the frontstage location and hit from a browser to finish activation.


### PR DESCRIPTION
Adding the one liner `docker exec -it postgres psql -U postgres -d postgres -c "update iac.iac set active = 't' where code = '4kyznty4fw3s'"` to the readme to make it easier to get started